### PR TITLE
Remove repetitive GitHub URLs for apps

### DIFF
--- a/lib/models/app.dart
+++ b/lib/models/app.dart
@@ -8,7 +8,7 @@ class App {
       'https://img.shields.io/github/stars/${repo}?style=social';
 
   String get md {
-    String linkedName = '[${name}](${url})';
+    String linkedName = '[${name}](${url ?? githubUrl})';
     String linkedBadgeStars =
         '[![GitHub Repo stars]($githubBadgeStars)]($githubUrl)';
     return '| $linkedName | $linkedBadgeStars | ${description} |';

--- a/source/open-source-apps.yaml
+++ b/source/open-source-apps.yaml
@@ -14,20 +14,15 @@
   url: https://yukino-app.github.io/
 - name: Harmonoid
   repo: harmonoid/harmonoid
-  url: https://github.com/harmonoid/harmonoid
 - name: Ubuntu Desktop Installer
   description: A modern implementation of the Ubuntu Desktop installer, using subiquity as a backend and Flutter for the UI.
   repo: canonical/ubuntu-desktop-installer
-  url: https://github.com/canonical/ubuntu-desktop-installer
 - name: AppImage Pool
   description: Simple and modern AppImageHub Client for Linux desktop.
   repo: prateekmedia/appimagepool
-  url: https://github.com/prateekmedia/appimagepool
 - name: FluTube
   description: Youtube video client + downloader made using flutter for mobile and desktop.
   repo: prateekmedia/flutube
-  url: https://github.com/prateekmedia/flutube
 - name: Sharik
   description: Sharik is an open-source, cross-platform solution for sharing files via Wi-Fi or Mobile Hotspot
   repo: marchellodev/sharik
-  url: https://github.com/marchellodev/sharik


### PR DESCRIPTION
Use the GitHub repo URL as a default for those apps that don't have a dedicated website. This Fixes the null URL of Invoice Ninja and allows removing some repetitive URLs.